### PR TITLE
Fixed case of auto-filter not returning to previous state after trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This RuneLite plugin tracks trades between other players, logging them for futur
 
 Logged trades specify the name of the player traded, the time the trade was accepted, and all items given and received.
 
-Additionally, these trade records use the GE prices of the items traded to calculate aggregate values of a trade.
+Trade records can be configured to use the High Alch, Low Alch, or GE prices of the items traded to calculate aggregate values of a trade.
 
 Simple exchanges of coins for a single type of item are summarized to display how much was paid per item.
 
@@ -21,7 +21,6 @@ Simple exchanges of coins for a single type of item are summarized to display ho
 * Trade records will collapse to save space and expand to show details
 * Option to automatically delete trades older than a configurable time
 * backup and restore trade histories to files
-* Supports calculating prices using low alch, high alch and GE price at the time of trade
 * Can right-click on player characters and players in interfaces to filter trades by their name
 * Screenshot accepted trades
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'org.asundr'
-version = '1.2.2'
+version = '1.2.3'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/org/asundr/ui/GuiUtils.java
+++ b/src/main/java/org/asundr/ui/GuiUtils.java
@@ -53,10 +53,14 @@ public class GuiUtils
 
     public static void setFilterAndEnabled(final String text)
     {
-        setFilter(text);
-        mainPanel.btnFilter.setActive(true);
+        SwingUtilities.invokeLater(()->
+        {
+            setFilter(text);
+            mainPanel.btnFilter.setActive(true);
+        });
     }
 
+    // Note: Must be called inside a SwingUtilities.invokeLater
     public static void clearFilter()
     {
         if (mainPanel == null)

--- a/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
+++ b/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
@@ -585,17 +585,16 @@ public class TradeTrackerPluginPanel extends PluginPanel
         }
     }
 
+    // Note: Must be called inside a SwingUtilities.invokeLater
     void setFilter(final String text)
     {
-        SwingUtilities.invokeLater(() ->
+        if (!text.equalsIgnoreCase(filterText.getText()))
         {
-            if (!text.equalsIgnoreCase(filterText.getText()))
-            {
-                filterText.setText(text);
-            }
-        });
+            filterText.setText(text);
+        }
     }
 
+    // Note: Must be called inside a SwingUtilities.invokeLater
     void clearFilter()
     {
         SwingUtilities.invokeLater(() -> filterText.setText(""));


### PR DESCRIPTION
Fixed #8 

Moved the call to SwingUtils.invokeLater to a more outer scope when setting the filter text to ensure that any subsequent instructions can be called and assume that the text has already been set.