### PR TITLE
Fixing trade history refresh bugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'org.asundr'
-version = '1.2.5'
+version = '1.2.6'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/org/asundr/recovery/SaveManager.java
+++ b/src/main/java/org/asundr/recovery/SaveManager.java
@@ -68,7 +68,7 @@ public class SaveManager
     private static SaveData_Common saveDataCommon;
     private static final AtomicInteger tradeHistorySaveState = new AtomicInteger(SaveState.INACTIVE); // flags for trade history save operation
     private static final AtomicInteger tradeHistoryLoadState = new AtomicInteger(SaveState.INACTIVE); // flags for trade history load operation
-    private static final ExecutorService ioExecutor = Executors.newFixedThreadPool(1);
+    private static ExecutorService ioExecutor = null;
     private static Future<?> ioExecutorFuture  = null;
 
     @Subscribe
@@ -123,6 +123,11 @@ public class SaveManager
     public static void initialize(ConfigManager configManager)
     {
         SaveManager.configManager = configManager;
+
+        SaveManager.ioExecutor =  Executors.newFixedThreadPool(1);
+        SaveManager.ioExecutorFuture = null;
+        SaveManager.tradeHistorySaveState.set(SaveState.INACTIVE);
+        SaveManager.tradeHistoryLoadState.set(SaveState.INACTIVE);
     }
 
     public static void shutdown()

--- a/src/main/java/org/asundr/recovery/SaveManager.java
+++ b/src/main/java/org/asundr/recovery/SaveManager.java
@@ -127,16 +127,13 @@ public class SaveManager
 
     public static void shutdown()
     {
-        if (CommonUtils.isThreadActive(ioExecutorFuture))
+        if (hasFlag(tradeHistorySaveState, SaveState.ACTIVE))
         {
-            if (hasFlag(tradeHistorySaveState, SaveState.ACTIVE))
-            {
-                ioExecutor.shutdown();
-            }
-            else
-            {
-                ioExecutor.shutdownNow();
-            }
+            ioExecutor.shutdown();
+        }
+        else
+        {
+            ioExecutor.shutdownNow();
         }
     }
 

--- a/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
+++ b/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
@@ -522,12 +522,12 @@ public class TradeTrackerPluginPanel extends PluginPanel
     {
         if (CommonUtils.isThreadActive(scheduledUpdateTimeFuture))
         {
-            scheduler.shutdownNow();
+            scheduledUpdateTimeFuture.cancel(true);
         }
         scheduledUpdateTimeFuture = scheduler.schedule(() -> {
             if (CommonUtils.isThreadActive(uiExecutorFuture))
             {
-                executor.shutdownNow();
+                uiExecutorFuture.cancel(true);
             }
             CommonUtils.getClientThread().invokeLater(() -> replaceAllTradeRecords(tradeHistory));
         }, TIME_RESTART_TRADE_RECORD_REFRESH, TimeUnit.SECONDS);
@@ -572,8 +572,11 @@ public class TradeTrackerPluginPanel extends PluginPanel
                 panels.forEach(TradeRecordPanel::updatePreferredSize); // fix for mis-sized panels on reload all
                 tradeHistoryPanel.setVisible(true);
                 updateEmptyHistoryMessages();
-                scheduler.shutdownNow();
-                scheduledUpdateTimeFuture = null;
+                if (scheduledUpdateTimeFuture != null)
+                {
+                    scheduledUpdateTimeFuture.cancel(true);
+                    scheduledUpdateTimeFuture = null;
+                }
                 uiExecutorFuture = null;
                 scheduledTimeLabelUpdate();
             });

--- a/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
+++ b/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
@@ -536,6 +536,11 @@ public class TradeTrackerPluginPanel extends PluginPanel
         if (tradeHistory == null || tradeHistory.isEmpty())
         {
             updateEmptyHistoryMessages();
+            if (scheduledUpdateTimeFuture != null)
+            {
+                scheduledUpdateTimeFuture.cancel(true);
+                scheduledUpdateTimeFuture = null;
+            }
             return;
         }
         btnFilter.setActive(false);

--- a/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
+++ b/src/main/java/org/asundr/ui/TradeTrackerPluginPanel.java
@@ -138,14 +138,8 @@ public class TradeTrackerPluginPanel extends PluginPanel
 
     public void shutdown()
     {
-        if (CommonUtils.isThreadActive(scheduledUpdateTimeFuture))
-        {
-            scheduler.shutdownNow();
-        }
-        if (CommonUtils.isThreadActive(uiExecutorFuture))
-        {
-            executor.shutdownNow();
-        }
+        scheduler.shutdownNow();
+        executor.shutdownNow();
     }
 
     @Subscribe


### PR DESCRIPTION
Fixes #21 
Executors were being incorrectly shutdown during the plugin's lifetime. This has been resolved by:
- calling cancel on the executor handles during the plugin's lifetime
- no longer checking if the executor is running when shutting down the executors on plugin shutdown

Note: consider making the save manager a proper singleton

<hr>

Fixes #20 
Cancels the executor used to restart refreshing the trade history panel after a timeout.